### PR TITLE
Corrige erro de responsividade

### DIFF
--- a/pages/admin/calendario.vue
+++ b/pages/admin/calendario.vue
@@ -282,4 +282,22 @@ span {
   margin: 0 auto;
   max-width: 900px;
 }
+
+@media screen and (max-width: 830px) and (min-width: 730px) {
+  .calendar-header {
+    border-radius: 4px 0 0 0;
+  }
+
+  .calendar-body {
+    border-radius: 0 0 0 4px;
+  }
+
+  .card-list-body {
+    border-radius: 0 0 4px 0;
+  }
+
+  .card-list-header {
+    border-radius: 0 4px 0 0;
+  }
+}
 </style>


### PR DESCRIPTION
No erro mostrado na issue (closes #48) os componente "grudam" um no outro na medida em que a tela diminui de tramanho. Sendo assim aproveitei esse "bug" e fiz com que eles se torne apenas um componente. No entanto, se a tela for do tamanho de um dispositivo móvel, os componentes se "desgrudam" e se deslocam em direção de coluna.


![Screen Capture_google-chrome_20200609100134](https://user-images.githubusercontent.com/26655732/84150583-71a8cd80-aa38-11ea-89e2-1684a55c6ce4.gif)
